### PR TITLE
feat: 이미지 업로드 구현

### DIFF
--- a/src/main/java/com/jointpurchases/domain/product/exception/ImageFailToUploadException.java
+++ b/src/main/java/com/jointpurchases/domain/product/exception/ImageFailToUploadException.java
@@ -1,0 +1,11 @@
+package com.jointpurchases.domain.product.exception;
+
+import com.jointpurchases.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ImageFailToUploadException extends RuntimeException {
+    private ErrorCode errorCode;
+}

--- a/src/main/java/com/jointpurchases/domain/product/model/entity/Product.java
+++ b/src/main/java/com/jointpurchases/domain/product/model/entity/Product.java
@@ -1,0 +1,63 @@
+package com.jointpurchases.domain.product.model.entity;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import com.jointpurchases.domain.category.model.entity.Category;
+import com.jointpurchases.domain.product.model.dto.ProductRequestDto;
+import com.jointpurchases.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String productName;
+
+    @Column(length = 1000, nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private Integer stockQuantity;
+
+    @Column(nullable = false)
+    private Integer likeCount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProductImage> productImages;
+
+    @Builder
+    public Product(String productName, String description, int price,
+                   int stockQuantity, int likeCount, User user, Category category) {
+        this.productName = productName;
+        this.description = description;
+        this.price = price;
+        this.stockQuantity = stockQuantity;
+        this.likeCount = likeCount;
+        this.user = user;
+        this.category = category;
+    }
+
+}

--- a/src/main/java/com/jointpurchases/domain/product/model/entity/ProductImage.java
+++ b/src/main/java/com/jointpurchases/domain/product/model/entity/ProductImage.java
@@ -1,0 +1,32 @@
+package com.jointpurchases.domain.product.model.entity;
+
+import com.jointpurchases.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id",nullable = false)
+    private Product product;
+
+    @Builder
+    public ProductImage(String imageUrl, Product product) {
+        this.imageUrl = imageUrl;
+        this.product = product;
+    }
+
+}

--- a/src/main/java/com/jointpurchases/domain/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/jointpurchases/domain/product/repository/ProductImageRepository.java
@@ -1,0 +1,7 @@
+package com.jointpurchases.domain.product.repository;
+
+import com.jointpurchases.domain.product.model.entity.ProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+}

--- a/src/main/java/com/jointpurchases/domain/product/service/S3ImageService.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/S3ImageService.java
@@ -1,0 +1,74 @@
+package com.jointpurchases.domain.product.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.jointpurchases.domain.product.exception.ImageFailToUploadException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static com.jointpurchases.global.exception.ErrorCode.FAIL_TO_UPLOAD_FILE;
+import static com.jointpurchases.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+
+@RequiredArgsConstructor
+@Service
+public class S3ImageService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3Client amazonS3Client;
+
+    // 이미지 단일업로드
+    public String upload(MultipartFile multipartFile) throws IOException{
+
+        ObjectMetadata metadata= new ObjectMetadata();
+        metadata.setContentType(multipartFile.getContentType());
+        metadata.setContentLength(multipartFile.getSize());
+
+        String fileName = generateFileName(multipartFile);
+        String fileUrl= "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" +fileName;
+
+        try {
+            amazonS3Client.putObject(bucket, fileName, multipartFile.getInputStream(), metadata);
+            return fileUrl;
+        } catch (IOException e) {
+           throw new ImageFailToUploadException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 이미지 다중업로드
+    public  List<String> upload(List<MultipartFile> multipartFiles) {
+        return multipartFiles.stream()
+                .map(multipartFile -> {
+                    try {
+                        return upload(multipartFile);
+                    } catch (IOException e) {
+                        throw new ImageFailToUploadException(FAIL_TO_UPLOAD_FILE);
+                    }
+                }).toList();
+    }
+
+
+    private String generateFileName(MultipartFile multipartFile) {
+        return UUID.randomUUID() + "." + multipartFile.getOriginalFilename();
+    }
+
+    public void deleteImage(String fileUrl) {
+        amazonS3Client.deleteObject(bucket, getDeleteKey(fileUrl));
+    }
+
+    private String getDeleteKey(String fileUrl) {
+        int lastIndex = fileUrl.lastIndexOf("/");
+        if (lastIndex == -1) {
+            throw new ImageFailToUploadException(FAIL_TO_UPLOAD_FILE);
+        }
+        return fileUrl.substring(lastIndex + 1);
+    }
+
+}


### PR DESCRIPTION
# 작업 내용 요약
1. product 엔티티, productImage 엔티티 구성
2. aws S3 이용한 이미지 업로드 구현

# 변경점
## AS-IS
- 이미지 단일업로드에서 다중 업로드 변경
-  파일명 충돌 방지 및 보안강화를 위해 파일이름에 uuid를 사용

## TO-BE



# 테스트
- 이미지 업로드시 awsS3 버켓에 업로드된다.
