### PR TITLE
Feature/product

### DIFF
--- a/src/main/java/com/jointpurchases/domain/product/controller/ProductController.java
+++ b/src/main/java/com/jointpurchases/domain/product/controller/ProductController.java
@@ -33,4 +33,16 @@ public class ProductController {
                 .body(ServiceResult.success("create success!"));
     }
 
+    @PutMapping("/product/{id}")
+    public ResponseEntity<?> updateProduct(
+            @PathVariable final Long id,
+            @RequestPart(value = "product") @Valid ProductRequestDto requestDto,
+            @RequestPart(value = "image") List<MultipartFile> files,
+            @AuthenticationPrincipal final UserDetailsImpl userDetails)
+    {
+        productService.updateProduct(id, requestDto,userDetails.getUser(), files);
+        return ResponseEntity.ok()
+                .body(ServiceResult.success("update success!"));
+    }
+
 }

--- a/src/main/java/com/jointpurchases/domain/product/controller/ProductController.java
+++ b/src/main/java/com/jointpurchases/domain/product/controller/ProductController.java
@@ -1,0 +1,36 @@
+package com.jointpurchases.domain.product.controller;
+
+import com.jointpurchases.domain.auth.sercurity.UserDetailsImpl;
+import com.jointpurchases.domain.product.model.dto.request.ProductRequestDto;
+import com.jointpurchases.domain.product.service.ProductService;
+import com.jointpurchases.global.common.ServiceResult;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ProductController {
+
+    private final ProductService productService;
+
+
+    @PostMapping("/product")
+    public ResponseEntity<?> createProduct(
+            @RequestPart(value = "product") @Valid ProductRequestDto requestDto,
+            @RequestPart(value = "image") List<MultipartFile> files,
+            @AuthenticationPrincipal final UserDetailsImpl userDetails)
+    {
+        productService.createProduct(requestDto, userDetails.getUser(), files);
+        return ResponseEntity.ok()
+                .body(ServiceResult.success("create success!"));
+    }
+
+}

--- a/src/main/java/com/jointpurchases/domain/product/controller/ProductController.java
+++ b/src/main/java/com/jointpurchases/domain/product/controller/ProductController.java
@@ -45,4 +45,13 @@ public class ProductController {
                 .body(ServiceResult.success("update success!"));
     }
 
+    @DeleteMapping("/product/{id}")
+    public ResponseEntity<?> deleteProduct(
+            @PathVariable final Long id,
+            @AuthenticationPrincipal final UserDetailsImpl userDetails)
+    {
+        productService.deleteProduct(id, userDetails.getUser());
+        return ResponseEntity.ok()
+                .body(ServiceResult.success("delete success!"));
+    }
 }

--- a/src/main/java/com/jointpurchases/domain/product/controller/ProductReadController.java
+++ b/src/main/java/com/jointpurchases/domain/product/controller/ProductReadController.java
@@ -1,0 +1,35 @@
+package com.jointpurchases.domain.product.controller;
+
+import com.jointpurchases.domain.product.service.ProductReadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ProductReadController {
+
+    private final ProductReadService productReadService;
+
+
+    @GetMapping("/products")
+    public ResponseEntity<?> getAllProduct(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size)
+    {
+        return ResponseEntity.ok()
+                .body(productReadService.getAllProduct(PageRequest.of(page - 1, size)));
+    }
+
+    @GetMapping("/products/{id}")
+    public ResponseEntity<?> getProduct(@PathVariable final Long id)
+    {
+        return ResponseEntity.ok()
+                .body(productReadService.getProduct(id));
+    }
+
+
+
+}

--- a/src/main/java/com/jointpurchases/domain/product/exception/ProductException.java
+++ b/src/main/java/com/jointpurchases/domain/product/exception/ProductException.java
@@ -1,0 +1,11 @@
+package com.jointpurchases.domain.product.exception;
+
+import com.jointpurchases.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ProductException extends RuntimeException {
+    private ErrorCode errorCode;
+}

--- a/src/main/java/com/jointpurchases/domain/product/model/dto/request/ProductRequestDto.java
+++ b/src/main/java/com/jointpurchases/domain/product/model/dto/request/ProductRequestDto.java
@@ -1,0 +1,33 @@
+package com.jointpurchases.domain.product.model.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record ProductRequestDto(
+
+        @NotBlank(message = "상품명을 입력해주세요.")
+        String productName,
+
+        @NotBlank(message = "카테고리를 입력해주세요")
+        String category,
+
+        @NotBlank(message = "내용을 입력해주세요")
+        @Size(max = 1000, message = "입력 제한을 넘었습니다.")
+        String description,
+
+        @NotNull(message = "가격을 입력해주세요.")
+        @Min(value = 0 ,message = "음수는 입력할수 없습니다.")
+        Integer price,
+
+        @NotNull(message = "수량을 입력해주세요.")
+        @Min(value = 0, message = "음수는 입력할수 없습니다.")
+        Integer stockQuantity,
+
+        List<MultipartFile> images
+) {
+}

--- a/src/main/java/com/jointpurchases/domain/product/model/dto/response/ProductListResponseDto.java
+++ b/src/main/java/com/jointpurchases/domain/product/model/dto/response/ProductListResponseDto.java
@@ -1,0 +1,37 @@
+package com.jointpurchases.domain.product.model.dto.response;
+
+import com.jointpurchases.domain.product.model.entity.Product;
+import com.jointpurchases.domain.product.model.entity.ProductImage;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ProductListResponseDto(
+        Long id,
+        String productName,
+        String userName,
+        Integer price,
+        String categoryName,
+        String imageUrl,
+        LocalDateTime createDate,
+        LocalDateTime modifiedDate
+
+) {
+
+    public static ProductListResponseDto of(Product product) {
+        return ProductListResponseDto.builder()
+                .id(product.getId())
+                .categoryName(product.getCategory().getCategoryName())
+                .productName(product.getProductName())
+                .userName(product.getUser().getUsername())
+                .price(product.getPrice())
+                .imageUrl(product.getProductImages().stream()
+                        .findFirst()
+                        .map(ProductImage::getImageUrl)
+                        .orElse(null))
+                .createDate(product.getCreatedAt())
+                .modifiedDate(product.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/product/model/dto/response/ProductResponseDto.java
+++ b/src/main/java/com/jointpurchases/domain/product/model/dto/response/ProductResponseDto.java
@@ -1,0 +1,43 @@
+package com.jointpurchases.domain.product.model.dto.response;
+
+import com.jointpurchases.domain.product.model.entity.Product;
+import com.jointpurchases.domain.product.model.entity.ProductImage;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record ProductResponseDto(
+        Long id,
+        String productName,
+        String userName,
+        String description,
+        Integer price,
+        Integer stockQuantity,
+        Integer likeCount,
+        String categoryName,
+        List<String> imageList,
+        LocalDateTime createDate,
+        LocalDateTime modifiedDate
+) {
+
+    public static ProductResponseDto of(Product product, int like) {
+        return ProductResponseDto.builder()
+                .id(product.getId())
+                .categoryName(product.getCategory().getCategoryName())
+                .productName(product.getProductName())
+                .userName(product.getUser().getUsername())
+                .description(product.getDescription())
+                .price(product.getPrice())
+                .stockQuantity(product.getStockQuantity())
+                .likeCount(product.getLikeCount() + like)
+                .imageList(product.getProductImages()
+                        .stream()
+                        .map(ProductImage::getImageUrl)
+                        .toList())
+                .createDate(product.getCreatedAt())
+                .modifiedDate(product.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/product/model/entity/Product.java
+++ b/src/main/java/com/jointpurchases/domain/product/model/entity/Product.java
@@ -3,6 +3,7 @@ package com.jointpurchases.domain.product.model.entity;
 import com.jointpurchases.domain.auth.model.entity.User;
 import com.jointpurchases.domain.category.model.entity.Category;
 import com.jointpurchases.domain.product.model.dto.ProductRequestDto;
+import com.jointpurchases.domain.product.model.dto.request.ProductRequestDto;
 import com.jointpurchases.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -60,4 +61,15 @@ public class Product extends BaseEntity {
         this.category = category;
     }
 
+    public void update(ProductRequestDto requestDto, List<ProductImage> productImages, Category category) {
+        this.category = category != null ? category : this.category;
+        this.productName = requestDto.productName() != null ? requestDto.productName() : this.productName;
+        this.description = requestDto.description() != null ? requestDto.description() : this.description;
+        this.stockQuantity = requestDto.stockQuantity() >= 0 ? requestDto.stockQuantity() : this.stockQuantity;
+        this.price = requestDto.price() >= 0 ? requestDto.price() : this.price;
+        if (!productImages.isEmpty()) {
+            this.productImages.clear();
+            this.productImages.addAll(productImages);
+        }
+    }
 }

--- a/src/main/java/com/jointpurchases/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/jointpurchases/domain/product/repository/ProductRepository.java
@@ -1,0 +1,14 @@
+package com.jointpurchases.domain.product.repository;
+
+import com.jointpurchases.domain.product.model.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+}

--- a/src/main/java/com/jointpurchases/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/jointpurchases/domain/product/repository/ProductRepository.java
@@ -11,4 +11,17 @@ import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+    @Query("SELECT p FROM Product p " +
+            "LEFT JOIN  p.user u " +
+            "LEFT JOIN  p.category c " +
+            "LEFT JOIN  p.productImages i " +
+            "WHERE p.id = :productId")
+    Optional<Product> findProductWithProductId(@Param("productId") Long productId);
+
+    @Query("SELECT p FROM Product p  " +
+            "LEFT JOIN FETCH p.user u " +
+            "LEFT JOIN FETCH p.category c " +
+            "LEFT JOIN FETCH p.productImages i "+
+            "ORDER BY p.createdAt DESC")
+    Page<Product> findAllProduct(Pageable pageable);
 }

--- a/src/main/java/com/jointpurchases/domain/product/service/ProductReadService.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/ProductReadService.java
@@ -1,0 +1,13 @@
+package com.jointpurchases.domain.product.service;
+
+import com.jointpurchases.domain.product.model.dto.response.ProductListResponseDto;
+import com.jointpurchases.domain.product.model.dto.response.ProductResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductReadService {
+
+    Page<ProductListResponseDto> getAllProduct(Pageable pageable);
+
+    ProductResponseDto getProduct(Long id);
+}

--- a/src/main/java/com/jointpurchases/domain/product/service/ProductService.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/ProductService.java
@@ -11,4 +11,5 @@ public interface ProductService {
 
     void createProduct(ProductRequestDto requestDto, User user, List<MultipartFile> files);
 
+    void updateProduct(Long id, ProductRequestDto requestDto, User user ,List<MultipartFile> files);
 }

--- a/src/main/java/com/jointpurchases/domain/product/service/ProductService.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/ProductService.java
@@ -1,0 +1,14 @@
+package com.jointpurchases.domain.product.service;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import com.jointpurchases.domain.product.model.dto.request.ProductRequestDto;
+import com.jointpurchases.domain.product.model.dto.response.ProductLikeResponseDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface ProductService {
+
+    void createProduct(ProductRequestDto requestDto, User user, List<MultipartFile> files);
+
+}

--- a/src/main/java/com/jointpurchases/domain/product/service/ProductService.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/ProductService.java
@@ -12,4 +12,7 @@ public interface ProductService {
     void createProduct(ProductRequestDto requestDto, User user, List<MultipartFile> files);
 
     void updateProduct(Long id, ProductRequestDto requestDto, User user ,List<MultipartFile> files);
+
+    void deleteProduct(Long id, User user);
+
 }

--- a/src/main/java/com/jointpurchases/domain/product/service/impl/ProductReadServiceImpl.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/impl/ProductReadServiceImpl.java
@@ -1,0 +1,40 @@
+package com.jointpurchases.domain.product.service.impl;
+
+import com.jointpurchases.domain.product.exception.ProductException;
+import com.jointpurchases.domain.product.model.dto.response.ProductListResponseDto;
+import com.jointpurchases.domain.product.model.dto.response.ProductResponseDto;
+import com.jointpurchases.domain.product.model.entity.Product;
+import com.jointpurchases.domain.product.repository.ProductRepository;
+import com.jointpurchases.domain.product.service.ProductReadService;
+import com.jointpurchases.global.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.jointpurchases.global.exception.ErrorCode.PRODUCT_NOT_FOUND;
+
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ProductReadServiceImpl implements ProductReadService {
+
+    private final ProductRepository productRepository;
+    private final RedisUtil redisUtil;
+
+
+    @Override
+    public Page<ProductListResponseDto> getAllProduct(Pageable pageable) {
+        Page<Product> productPage = productRepository.findAllProduct(pageable);
+        return productPage.map(ProductListResponseDto::of);
+    }
+
+    @Override
+    public ProductResponseDto getProduct(Long id) {
+        Product product = productRepository.findProductWithProductId(id)
+                .orElseThrow(()-> new ProductException(PRODUCT_NOT_FOUND));
+        return ProductResponseDto.of(product, redisUtil.getLikeCount(id));
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/impl/ProductServiceImpl.java
@@ -72,6 +72,17 @@ public class ProductServiceImpl implements ProductService {
         product.update(requestDto, productImages, category);
     }
 
+    @Transactional
+    @Override
+    public void deleteProduct(Long id, User user) {
+        Product product = findProductOrElseThrow(id);
+        checkUserProduct(product, user);
+
+        deleteImageS3(product.getProductImages());
+        productRepository.delete(product);
+    }
+
+    
     private void deleteImageS3(List<ProductImage> images) {
         if (images.isEmpty()) return;
 

--- a/src/main/java/com/jointpurchases/domain/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/impl/ProductServiceImpl.java
@@ -1,0 +1,82 @@
+package com.jointpurchases.domain.product.service.impl;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import com.jointpurchases.domain.category.exception.CategoryException;
+import com.jointpurchases.domain.category.model.entity.Category;
+import com.jointpurchases.domain.category.repository.CategoryRepository;
+import com.jointpurchases.domain.product.exception.ProductException;
+import com.jointpurchases.domain.product.model.dto.request.ProductRequestDto;
+import com.jointpurchases.domain.product.model.dto.response.ProductLikeResponseDto;
+import com.jointpurchases.domain.product.model.entity.Product;
+import com.jointpurchases.domain.product.model.entity.ProductImage;
+import com.jointpurchases.domain.product.repository.ProductImageRepository;
+import com.jointpurchases.domain.product.repository.ProductRepository;
+import com.jointpurchases.domain.product.service.ProductService;
+import com.jointpurchases.domain.product.service.S3ImageService;
+import com.jointpurchases.global.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.jointpurchases.global.exception.ErrorCode.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+    private final ProductRepository productRepository;
+    private final CategoryRepository categoryRepository;
+    private final ProductImageRepository productImageRepository;
+    private final S3ImageService s3ImageService;
+
+    private static final int MAXIMUM_IMAGES = 5;    // 이미지 업로드 최대 개수
+
+
+    @Transactional
+    @Override
+    public void createProduct(ProductRequestDto requestDto, User user, List<MultipartFile> files) {
+        Category category = findCategoryOrElseThrow(requestDto.category());
+        checkImageUploadLimit(files);
+
+        Product product = productRepository.save(Product.builder()
+                        .user(user)
+                        .category(category)
+                        .productName(requestDto.productName())
+                        .description(requestDto.description())
+                        .stockQuantity(requestDto.stockQuantity())
+                        .price(requestDto.price())
+                        .likeCount(0)
+                        .build());
+
+        List<ProductImage> productImages = imageUpload(product, files);
+        productImageRepository.saveAll(productImages);
+    }
+
+
+    private List<ProductImage> imageUpload(Product product, List<MultipartFile> files) {
+        List<String> imageNameList = s3ImageService.upload(files);
+        return imageNameList
+                .stream()
+                .map(imageUrl -> new ProductImage(imageUrl, product))
+                .toList();
+    }
+
+    private void checkImageUploadLimit(List<MultipartFile> files) {
+        if (files.size() > MAXIMUM_IMAGES) {
+            throw new ProductException(UPLOAD_MAXIMUM_IMAGE);
+        }
+    }
+
+    private Category findCategoryOrElseThrow(String categoryName) {
+        return categoryRepository.findByCategoryName(categoryName)
+                .orElseThrow(()-> new CategoryException(NOT_FOUND_CATEGORY));
+    }
+
+
+}

--- a/src/main/java/com/jointpurchases/domain/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/jointpurchases/domain/product/service/impl/ProductServiceImpl.java
@@ -82,7 +82,7 @@ public class ProductServiceImpl implements ProductService {
         productRepository.delete(product);
     }
 
-    
+
     private void deleteImageS3(List<ProductImage> images) {
         if (images.isEmpty()) return;
 

--- a/src/main/java/com/jointpurchases/global/exception/ErrorCode.java
+++ b/src/main/java/com/jointpurchases/global/exception/ErrorCode.java
@@ -14,7 +14,9 @@ public enum ErrorCode {
     NOT_FOUND_CATEGORY(HttpStatus.BAD_REQUEST, "해당 카테고리가 존재하지 않습니다."),
 
     UPLOAD_MAXIMUM_IMAGE(HttpStatus.BAD_REQUEST, "최대 3장의 이미지만 업로드할 수 있습니다."),
-    FAIL_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "이미지 업로드에 실패했습니다.")
+    FAIL_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "이미지 업로드에 실패했습니다."),
+
+    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당상품이 존재하지 않습니다."),
     ;
 
     private final HttpStatus statusCode;

--- a/src/main/java/com/jointpurchases/global/exception/ErrorCode.java
+++ b/src/main/java/com/jointpurchases/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     FAIL_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "이미지 업로드에 실패했습니다."),
 
     PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당상품이 존재하지 않습니다."),
+    NOT_PRODUCT_BY_USER(HttpStatus.BAD_REQUEST, "회원님이 등록한 상품이 아닙니다."),
     ;
 
     private final HttpStatus statusCode;


### PR DESCRIPTION
# 작업 내용 요약
- 상품 등록
- 상품 업데이트
- 상품 삭제
- 상품 전체조회, 단일조회

# 변경점
## AS-IS
- 단일조회 like부분을 redis를 이용해서 조회
- 전체조회를 페이징을 이용해서 조회 1페이지당 10개상품 목록
- 전체조회는 대표이미지 첫번째 1개만 나오게 설정

## TO-BE
- 좋아요 기능 구현


# 테스트
- 전체 조회
![스크린샷 2024-02-07 110134](https://github.com/joint-purchase/joint-purchase/assets/112931862/45319ffa-c255-4064-96bd-8eeccc0dc320)

- 단일 조회
![스크린샷 2024-02-07 111857](https://github.com/joint-purchase/joint-purchase/assets/112931862/368dd593-2795-4ff7-941a-161583bd6d85)
