### PR TITLE
feat/security-token : 요청에 쓰일 토큰을 다루기 위한 서비스 클래스 구현

### DIFF
--- a/src/main/java/com/jointpurchases/domain/security/auth/AuthenticationController.java
+++ b/src/main/java/com/jointpurchases/domain/security/auth/AuthenticationController.java
@@ -19,19 +19,19 @@ public class AuthenticationController {
     private final AuthenticationService service;
 
     @PostMapping("/register")
-    public ResponseEntity<AuthenticationResponse> register(@RequestBody RegisterRequest request) {
-        return ResponseEntity.ok(service.register(request));
+    public ResponseEntity<AuthenticationResponse> register(@RequestBody RegisterRequest registerRequest) {
+        return ResponseEntity.ok(service.register(registerRequest));
     }
 
     @PostMapping("/authenticate")
-    public ResponseEntity<AuthenticationResponse> register(@RequestBody AuthenticationRequest request) {
-        return ResponseEntity.ok(service.authenticate(request));
+    public ResponseEntity<AuthenticationResponse> register(@RequestBody AuthenticationRequest authenticationRequest) {
+        return ResponseEntity.ok(service.authenticate(authenticationRequest));
     }
 
     @PostMapping("/refresh-token")
-    public void refreshToken(HttpServletRequest request,
-                             HttpServletResponse response) throws IOException {
-        service.refreshToken(request, response);
+    public void refreshToken(HttpServletRequest httpServletRequest,
+                             HttpServletResponse httpServletResponse) throws IOException {
+        service.refreshToken(httpServletRequest, httpServletResponse);
     }
 }
 

--- a/src/main/java/com/jointpurchases/domain/security/auth/AuthenticationController.java
+++ b/src/main/java/com/jointpurchases/domain/security/auth/AuthenticationController.java
@@ -19,12 +19,12 @@ public class AuthenticationController {
     private final AuthenticationService service;
 
     @PostMapping("/register")
-    public ResponseEntity<AuthenticationResponse> register(@RequestBody RegisterRequest registerRequest) {
+    public ResponseEntity<RegisterResponse> register(@RequestBody RegisterRequest registerRequest) {
         return ResponseEntity.ok(service.register(registerRequest));
     }
 
     @PostMapping("/authenticate")
-    public ResponseEntity<AuthenticationResponse> register(@RequestBody AuthenticationRequest authenticationRequest) {
+    public ResponseEntity<AuthenticationResponse> authenticate(@RequestBody AuthenticationRequest authenticationRequest) {
         return ResponseEntity.ok(service.authenticate(authenticationRequest));
     }
 

--- a/src/main/java/com/jointpurchases/domain/security/auth/AuthenticationService.java
+++ b/src/main/java/com/jointpurchases/domain/security/auth/AuthenticationService.java
@@ -33,7 +33,7 @@ public class AuthenticationService {
 
 
     // 회원가입
-    public AuthenticationResponse register(RegisterRequest request) {
+    public RegisterResponse register(RegisterRequest request) {
 
         if (!request.getPassword().equals(request.getConfirmPassword())) {
             throw new RuntimeException("Error: Passwords do not match!");
@@ -55,7 +55,7 @@ public class AuthenticationService {
         String jwtToken = jwtService.generateToken(user);
         String refreshToken = jwtService.generateRefreshToken(user);
         saveUserToken(savedUser, jwtToken);
-        return AuthenticationResponse.builder()
+        return RegisterResponse.builder()
                 .accessToken(jwtToken).refreshToken(refreshToken).build();
     }
 

--- a/src/main/java/com/jointpurchases/domain/security/auth/RegisterResponse.java
+++ b/src/main/java/com/jointpurchases/domain/security/auth/RegisterResponse.java
@@ -9,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class AuthenticationResponse {
+public class RegisterResponse {
 
     @JsonProperty("access_token")
     private String accessToken;

--- a/src/main/java/com/jointpurchases/domain/security/config/JwtService.java
+++ b/src/main/java/com/jointpurchases/domain/security/config/JwtService.java
@@ -20,13 +20,13 @@ public class JwtService {
 
 
     @Value("${application.security.jwt.secret-key}")
-    private static String secretKey;
+    private String secretKey;
 
     @Value("${application.security.jwt.expiration}")
-    private static long jwtExpiration;
+    private long jwtExpiration;
 
     @Value("${application.security.jwt.refresh-token.expiration}")
-    private static long refreshExpiration;
+    private long refreshExpiration;
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);

--- a/src/main/java/com/jointpurchases/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/jointpurchases/domain/security/config/SecurityConfig.java
@@ -33,23 +33,20 @@ public class SecurityConfig {
 
 
         http
-                .csrf()
-                .disable()
+                .csrf().disable()
                 .authorizeHttpRequests()
-                .requestMatchers("/api/v1/auth/**", "login","/","register") // white list - 인증 불요
-                .permitAll()
-                .anyRequest() // white list 제외 인증 필요
-                .authenticated()
+                    .requestMatchers("/api/v1/auth/**", "login","/","register").permitAll() // white list - 인증 불요
+                    .anyRequest().authenticated() // white list 제외 인증 필요
                 .and()
                 .sessionManagement()// 세션관리 - jwt로 인증하기 때문에 무상태성으로 전환
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authenticationProvider(authenticationProvider)
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                    .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .logout()
-                .logoutUrl("/api/v1/auth/logout")
-                .addLogoutHandler(logoutHandler)
-                .logoutSuccessHandler((request, response, authentication) -> SecurityContextHolder.clearContext())
+                    .logoutUrl("/api/v1/auth/logout")
+                    .addLogoutHandler(logoutHandler)
+                    .logoutSuccessHandler((request, response, authentication) -> SecurityContextHolder.clearContext())
         ;
 
         return http.build();

--- a/src/main/java/com/jointpurchases/domain/security/http/change-password.http
+++ b/src/main/java/com/jointpurchases/domain/security/http/change-password.http
@@ -1,0 +1,51 @@
+### 회원가입
+POST http://localhost:8080/api/v1/auth/register
+Content-Type: application/json
+
+{
+  "username":"kimlee",
+  "password":"password",
+  "confirmPassword":"password",
+  "email":"abcd@gmail.com",
+  "address":"takemehome",
+  "birth":"2002-02-02",
+  "phone":"01012345678",
+  "role": "USER"
+}
+
+> {%
+    client.global.set("auth-token", response.body.access_token);
+%}
+
+
+###  데모포인트 확인
+GET http://localhost:8080/api/v1/demo-controller
+Authorization: Bearer {{auth-token}}
+
+### 비밀번호 변경
+PATCH http://localhost:8080/api/v1/users
+Content-Type: application/json
+Authorization: Bearer {{auth-token}}
+
+{
+  "currentPassword": "password",
+  "newPassword": "newPassword",
+  "confirmationPassword": "newPassword"
+}
+
+### 재로그인과 토크인 갱신
+POST http://localhost:8080/api/v1/auth/authenticate
+Content-Type: application/json
+
+{
+  "email": "abcd@gmail.com",
+  "password": "newPassword"
+}
+
+> {%
+    client.global.set("new-auth-token", response.body.access_token);
+%}
+
+### 데모포인트 확인
+GET http://localhost:8080/api/v1/demo-controller
+Authorization: Bearer {{new-auth-token}}

--- a/src/main/java/com/jointpurchases/domain/security/test/DemoController.java
+++ b/src/main/java/com/jointpurchases/domain/security/test/DemoController.java
@@ -1,0 +1,16 @@
+package com.jointpurchases.domain.security.test;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/demo-controller")
+public class DemoController {
+
+    @GetMapping
+    public ResponseEntity<String> sayHello() {
+        return ResponseEntity.ok("Hello from secured Endpoint");
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/security/token/TokenManagementService.java
+++ b/src/main/java/com/jointpurchases/domain/security/token/TokenManagementService.java
@@ -1,0 +1,42 @@
+package com.jointpurchases.domain.security.token;
+
+import org.springframework.stereotype.Service;
+import java.util.HashMap;
+import java.util.Map;
+
+// 다른 API에서 토큰을 직접 다루기 위한 서비스
+
+@Service
+public class TokenManagementService {
+
+    // 토큰을 위한 메모리 저장소 - 해시맵으로 구현
+    private final Map<String, String> accessTokenStore = new HashMap<>();
+    private final Map<String, String> refreshTokenStore = new HashMap<>();
+
+    // 토큰 저장
+    public void storeAccessToken(String userId, String accessToken) {
+        accessTokenStore.put(userId, accessToken);
+    }
+
+    public void storeRefreshToken(String userId, String refreshToken) {
+        refreshTokenStore.put(userId, refreshToken);
+    }
+
+    // 토큰 접근
+    public String getAccessToken(String userId) {
+        return accessTokenStore.get(userId);
+    }
+
+    public String getRefreshToken(String userId) {
+        return refreshTokenStore.get(userId);
+    }
+
+    // 토큰 삭제
+    public void removeAccessToken(String userId) {
+        accessTokenStore.remove(userId);
+    }
+
+    public void removeRefreshToken(String userId) {
+        refreshTokenStore.remove(userId);
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/security/user/ChangePasswordRequest.java
+++ b/src/main/java/com/jointpurchases/domain/security/user/ChangePasswordRequest.java
@@ -1,0 +1,15 @@
+package com.jointpurchases.domain.security.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ChangePasswordRequest {
+
+    private String currentPassword;
+    private String newPassword;
+    private String confirmationPassword;
+}

--- a/src/main/java/com/jointpurchases/domain/security/user/UserController.java
+++ b/src/main/java/com/jointpurchases/domain/security/user/UserController.java
@@ -1,0 +1,28 @@
+package com.jointpurchases.domain.security.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    // 비밀번호 수정 endpoint
+    @PatchMapping
+    public ResponseEntity<?> changePassword(
+            @RequestBody ChangePasswordRequest changePasswordRequest,
+            Principal connectedUser
+    ) {
+        userService.changePassword(changePasswordRequest, connectedUser);
+        return ResponseEntity.accepted().build();
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/security/user/UserService.java
+++ b/src/main/java/com/jointpurchases/domain/security/user/UserService.java
@@ -1,0 +1,41 @@
+package com.jointpurchases.domain.security.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+
+    /**
+     * 비밀번호 변경 메서드
+     * @param changePasswordRequest : 비밀번호 변경 요청
+     * @param connectedUser : 현재 로그인한 사용자 정보
+     */
+    public void changePassword(ChangePasswordRequest changePasswordRequest, Principal connectedUser) {
+
+        // 사용자 정보 저장
+        var user = ((User) ((UsernamePasswordAuthenticationToken) connectedUser).getPrincipal());
+
+        // 현재 입력한 비밀번호가 맞는 지 확인하기
+        if(!passwordEncoder.matches(changePasswordRequest.getCurrentPassword(), user.getPassword())){
+            throw new IllegalStateException("입력한 비밀번호가 잘못되었습니다.");
+        }
+        // 암호 두개가 일치하는 지 확인
+        if(!changePasswordRequest.getNewPassword().equals(changePasswordRequest.getConfirmationPassword())){
+            throw new IllegalStateException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 암호 재설정
+        user.setPassword(passwordEncoder.encode(changePasswordRequest.getNewPassword()));
+        userRepository.save(user);
+    }
+}


### PR DESCRIPTION
# 작업 내용 요약
요청 때 쓰일 토큰을 저장한 객체를 다룰 수 있는 서비스 클래스를 구현했습니다.

# 변경점
## AS-IS


## TO-BE

# 테스트

# 논의사항
access, refresh 토큰 정보를 TokenManagementService를 활용해서 접근할 수 있습니다만, 이 객체가 필요한 게 맞나요?

