### PR TITLE
Feature/crate order

### DIFF
--- a/src/main/java/com/jointpurchases/domain/order/controller/OrderController.java
+++ b/src/main/java/com/jointpurchases/domain/order/controller/OrderController.java
@@ -1,0 +1,29 @@
+package com.jointpurchases.domain.order.controller;
+
+import com.jointpurchases.domain.order.model.dto.CancelOrder;
+import com.jointpurchases.domain.order.model.dto.CreateOrder;
+import com.jointpurchases.domain.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/order")
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderService orderService;
+
+    //상품 주문
+    @PostMapping
+    public CreateOrder.Response createOrder(@RequestBody CreateOrder.Request request) {
+
+        return CreateOrder.Response.fromDto(
+                this.orderService.createOrder(request.getEmail(), request.getMoney(),
+                        request.getAddress()));
+    }
+
+    //상품 주문 취소
+    @PutMapping
+    public CancelOrder.Response cancelOrder(@RequestBody CancelOrder.Request request) {
+        return this.orderService.cancelOrder(request.getEmail(), request.getOrderId());
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/order/model/dto/CancelOrder.java
+++ b/src/main/java/com/jointpurchases/domain/order/model/dto/CancelOrder.java
@@ -1,0 +1,32 @@
+package com.jointpurchases.domain.order.model.dto;
+
+import com.jointpurchases.domain.order.model.entity.OrderEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+public class CancelOrder {
+
+    @Getter
+    public static class Request {
+        private String email;
+        private Long orderId;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+        private String email;
+        private Long orderId;
+        private Long money;
+        private String payment;
+
+        public static Response from(OrderEntity order, Long money) {
+            return Response.builder()
+                    .email(order.getMemberEntity().getEmail())
+                    .orderId(order.getOrderId())
+                    .payment(order.getPayment())
+                    .money(money)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/order/model/dto/CreateOrder.java
+++ b/src/main/java/com/jointpurchases/domain/order/model/dto/CreateOrder.java
@@ -1,0 +1,43 @@
+package com.jointpurchases.domain.order.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CreateOrder {
+
+    @Getter
+    public static class Request {
+        private String email;
+        private Long money;
+        private String address;
+    }
+
+    @Getter
+    @Builder
+    public static class Response {
+        private Long orderId;
+        private String name;
+        private List<Long> productIdList;
+        private String address;
+        private String phone;
+        private LocalDateTime orderedDate;
+        private String payment;
+        private String type;
+
+        public static Response fromDto(OrderDto orderDto) {
+            return Response.builder()
+                    .name(orderDto.getName())
+                    .orderId(orderDto.getOrderId())
+                    .productIdList(orderDto.getProductIdList())
+                    .address(orderDto.getAddress())
+                    .phone(orderDto.getPhone())
+                    .orderedDate(orderDto.getOrderedDate())
+                    .payment(orderDto.getPayment())
+                    .type(orderDto.getType())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/order/model/dto/OrderDto.java
+++ b/src/main/java/com/jointpurchases/domain/order/model/dto/OrderDto.java
@@ -1,0 +1,36 @@
+package com.jointpurchases.domain.order.model.dto;
+
+import com.jointpurchases.domain.order.model.entity.OrderEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class OrderDto {
+    private Long orderId;
+    private String email;
+    private String name;
+    private List<Long> productIdList;
+    private String address;
+    private String phone;
+    private LocalDateTime orderedDate;
+    private String payment;
+    private String type;
+
+    public static OrderDto from(List<Long> productIdList, String address, OrderEntity order) {
+        return OrderDto.builder()
+                .orderId(order.getOrderId())
+                .email(order.getMemberEntity().getEmail())
+                .name(order.getMemberEntity().getName())
+                .address(address)
+                .phone(order.getMemberEntity().getPhone())
+                .orderedDate(LocalDateTime.now())
+                .productIdList(productIdList)
+                .payment(order.getPayment())
+                .type(order.getType())
+                .build();
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/order/model/entity/OrderEntity.java
+++ b/src/main/java/com/jointpurchases/domain/order/model/entity/OrderEntity.java
@@ -1,7 +1,7 @@
 package com.jointpurchases.domain.order.model.entity;
 
 import com.jointpurchases.domain.cart.model.entity.CartEntity;
-import com.jointpurchases.global.common.entity.BaseEntity;
+import com.jointpurchases.domain.cart.model.entity.MemberEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,21 +10,34 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Entity(name = "order")
+@Entity(name = "order_table")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class OrderEntity extends BaseEntity {
+public class OrderEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long orderId;
 
-    @OneToOne
-    @JoinColumn(name = "cartId")
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private MemberEntity memberEntity;
+
+    @ManyToOne
+    @JoinColumn(name = "cart_id")
     private CartEntity cartEntity;
 
     private String payment;
 
     private LocalDateTime orderedDate;
+
+    private String address;
+
+    private String type;
+
+    public void cancelOrder() {
+        this.payment = "주문 취소";
+    }
 }

--- a/src/main/java/com/jointpurchases/domain/order/service/OrderService.java
+++ b/src/main/java/com/jointpurchases/domain/order/service/OrderService.java
@@ -1,12 +1,185 @@
 package com.jointpurchases.domain.order.service;
 
+import com.jointpurchases.domain.cart.model.entity.CartEntity;
+import com.jointpurchases.domain.cart.model.entity.CartItemEntity;
+import com.jointpurchases.domain.cart.model.entity.MemberEntity;
+import com.jointpurchases.domain.cart.model.entity.ProductEntity;
+import com.jointpurchases.domain.cart.repository.CartItemRepository;
+import com.jointpurchases.domain.cart.repository.CartRepository;
+import com.jointpurchases.domain.cart.repository.MemberRepository;
+import com.jointpurchases.domain.cart.repository.ProductRepository;
+import com.jointpurchases.domain.order.model.dto.CancelOrder;
+import com.jointpurchases.domain.order.model.dto.OrderDto;
+import com.jointpurchases.domain.order.model.entity.OrderEntity;
 import com.jointpurchases.domain.order.repository.OrderRepository;
+import com.jointpurchases.domain.point.model.entity.PointEntity;
+import com.jointpurchases.domain.point.repository.PointRepository;
+import com.jointpurchases.domain.point.service.PointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class OrderService {
     private final OrderRepository orderRepository;
+    private final CartRepository cartRepository;
+    private final MemberRepository memberRepository;
+    private final CartItemRepository cartItemRepository;
+    private final PointRepository pointRepository;
+    private final ProductRepository productRepository;
+    private final PointService pointService;
+
+    //상품 주문
+    @Transactional
+    public OrderDto createOrder(String email, Long money, String address) {
+        MemberEntity memberEntity = getMemberEntity(email);
+
+        CartEntity cartEntity = getCartEntity(memberEntity);
+
+        List<CartItemEntity> cartItemEntityList =
+                this.cartItemRepository.findAllByCartEntity(cartEntity);
+
+        if (cartItemEntityList.isEmpty()) {
+            throw new RuntimeException("장바구니에 담긴 상품이 없습니다.");
+        }
+
+        Long totalPrice = cartEntity.getTotalPrice();
+        if (totalPrice > money) {
+            throw new RuntimeException("결제 금액이 부족합니다.");
+        }
+
+        Long currentPoint = this.pointService.getPoint(email).getCurrentPoint();
+        if (currentPoint < money) {
+            throw new RuntimeException("포인트 잔액이 부족합니다.");
+        }
+
+        OrderEntity orderEntity = this.orderRepository.save(OrderEntity.builder()
+                .cartEntity(cartEntity)
+                .memberEntity(memberEntity)
+                .orderedDate(LocalDateTime.now())
+                .payment("결제 완료")
+                .address(address)
+                .type("일반 구매")
+                .build());
+
+        List<Long> productIdList = cartItemEntityList.stream().map(item ->
+                item.getProductEntity().getProductId()).toList();
+
+        decreaseProductStock(productIdList, cartItemEntityList);
+
+        this.pointRepository.save(PointEntity.builder()
+                .memberEntity(memberEntity)
+                .changedPoint(money * -1)
+                .currentPoint(currentPoint - money)
+                .eventType("상품 구매")
+                .createdDate(LocalDateTime.now())
+                .build());
+
+        return OrderDto.from(productIdList, address, orderEntity);
+    }
+
+    //상품 주문 취소
+    @Transactional
+    public CancelOrder.Response cancelOrder(String email, Long orderId) {
+        MemberEntity memberEntity = getMemberEntity(email);
+
+        OrderEntity orderEntity = this.orderRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new RuntimeException(" 잘못된 주문 번호 입니다."));
+
+        if (orderEntity.getMemberEntity() != memberEntity) {
+            throw new RuntimeException("구매자의 정보가 일치하지 않습니다.");
+        }
+
+        //주문 취소로 주문 상태 변경
+        orderEntity.cancelOrder();
+
+        //장바구니의 상품들 재고 증가
+        CartEntity cartEntity = this.cartRepository.findByMemberEntity(memberEntity)
+                .orElseThrow(() -> new RuntimeException("장바구니가 없습니다."));
+
+        List<CartItemEntity> cartItemEntityList =
+                this.cartItemRepository.findAllByCartEntity(cartEntity);
+
+        List<Long> productIdList = cartItemEntityList.stream().map(item ->
+                item.getProductEntity().getProductId()).toList();
+
+        increaseProductStock(productIdList, cartItemEntityList);
+
+        //포인트 환불
+        Long refundPoint = cartEntity.getTotalPrice();
+
+        Long currentPoint = this.pointService.getPoint(email).getCurrentPoint();
+
+        this.pointRepository.save(PointEntity.builder()
+                .memberEntity(memberEntity)
+                .changedPoint(refundPoint)
+                .currentPoint(currentPoint + refundPoint)
+                .createdDate(LocalDateTime.now())
+                .eventType("상품 주문 취소")
+                .build());
+
+        return CancelOrder.Response.from(this.orderRepository.save(orderEntity),
+                refundPoint);
+    }
+
+    //주문된 상품의 재고 차감
+    private void decreaseProductStock(List<Long> productIdList, List<CartItemEntity> cartItemEntityList) {
+        Map<Long, ProductEntity> productEntityMap = getProductEntityMap(productIdList);
+
+        cartItemEntityList.forEach(cartItem -> {
+            Long productId = cartItem.getProductEntity().getProductId();
+            ProductEntity productEntity = productEntityMap.get(productId);
+            if (productEntity == null) {
+                throw new RuntimeException("상품 정보를 찾을 수 없습니다.");
+            }
+            Long amount = cartItem.getAmount();
+            productEntity.decreaseStock(amount);
+        });
+
+        this.productRepository.saveAll(productEntityMap.values());
+    }
+
+    //주문 취소된 상품의 재고 증가
+    private void increaseProductStock(List<Long> productIdList, List<CartItemEntity> cartItemEntityList) {
+        Map<Long, ProductEntity> productEntityMap = getProductEntityMap(productIdList);
+
+        cartItemEntityList.forEach(cartItem -> {
+            Long productId = cartItem.getProductEntity().getProductId();
+            ProductEntity productEntity = productEntityMap.get(productId);
+            if (productEntity == null) {
+                throw new RuntimeException("상품 정보를 찾을 수 없습니다.");
+            }
+            Long amount = cartItem.getAmount();
+            productEntity.increaseStock(amount);
+        });
+
+        this.productRepository.saveAll(productEntityMap.values());
+    }
+
+    //주문 상품의 productIdList를 입력받아 ProductEntity를 일괄 검색 >> map으로 만들어 반환
+    private Map<Long, ProductEntity> getProductEntityMap(List<Long> productIdList) {
+        List<ProductEntity> productEntityList
+                = this.productRepository.findAllByProductIdIn(productIdList);
+
+        return productEntityList.stream().collect(Collectors
+                .toMap(ProductEntity::getProductId, Function.identity()));
+    }
+
+    private CartEntity getCartEntity(MemberEntity memberEntity) {
+        return cartRepository.findByMemberEntity(memberEntity)
+                .orElseThrow(() -> new RuntimeException("장바구니가 존재하지 않습니다."));
+    }
+
+    private MemberEntity getMemberEntity(String email) {
+        return this.memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 아이디 입니다."));
+    }
 
 }


### PR DESCRIPTION
# 작업 내용 요약
- 상품 주문, 상품 주문 취소 API 구현
- order테이블의 이름을 order_table로 변경

# 변경점
## AS-IS


## TO-BE
- 주문할 상품을 productIdList로 검색 후 <productId, productEntity> map을 만들어 반환

            private Map<Long, ProductEntity> getProductEntityMap(List<Long> productIdList) {
                    List<ProductEntity> productEntityList
                            = this.productRepository.findAllByProductIdIn(productIdList);
            
                    return productEntityList.stream().collect(Collectors
                            .toMap(ProductEntity::getProductId, Function.identity()));
            }

- 재고 차감, 재고 증가 시 map에서 productId에 해당하는 productEntity를 찾고, 재고 수량 처리

            cartItemEntityList.forEach(cartItem -> {
                        Long productId = cartItem.getProductEntity().getProductId();
                        ProductEntity productEntity = productEntityMap.get(productId);
                        if (productEntity == null) {
                            throw new RuntimeException("상품 정보를 찾을 수 없습니다.");
                        }
                        Long amount = cartItem.getAmount();
                        productEntity.decreaseStock(amount);
             });

## 보완해야 할 부분
- 상품 주문 취소 시 차감된 point 증가에 대한 부분은 구현 못했습니다. 


# 테스트
- 상품 주문
![image](https://github.com/joint-purchase/joint-purchase/assets/141150761/ef4cb657-27b8-424e-80e1-1d548490113d)

- 상품 주문 취소
![image](https://github.com/joint-purchase/joint-purchase/assets/141150761/1ab30688-5203-4000-a70a-29b670d8c599)


