### PR TITLE
마감 기간 생성,수정,삭제 구현/ 공동 구매 팀 생성, 인원추가, 삭제 구현

### DIFF
--- a/src/main/java/com/jointpurchases/JointPurchasesApplication.java
+++ b/src/main/java/com/jointpurchases/JointPurchasesApplication.java
@@ -2,8 +2,10 @@ package com.jointpurchases;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class JointPurchasesApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/jointpurchases/domain/deadline/controller/DeadlineController.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/controller/DeadlineController.java
@@ -1,0 +1,36 @@
+package com.jointpurchases.domain.deadline.controller;
+
+import com.jointpurchases.domain.deadline.model.dto.CeateDeadlineDto;
+import com.jointpurchases.domain.deadline.model.dto.ModifyDeadlineDto;
+import com.jointpurchases.domain.deadline.service.DeadlineService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/deadline")
+public class DeadlineController {
+    private final DeadlineService deadlineService;
+/*
+마감 기간 생성
+ */
+    @PostMapping
+    public CeateDeadlineDto.Response createDeadline(@RequestPart(name = "dto") CeateDeadlineDto.Request request){
+        return deadlineService.createDeadline(request.getProductId(), request.getPeriod(), request.getMaximumPeople());
+    }
+/*
+마감 기간 수정
+ */
+    @PutMapping
+    public ModifyDeadlineDto.Response modifyDeadline(@RequestPart(name = "dto") ModifyDeadlineDto.Request request){
+        return deadlineService.modifyDeadline(request.getDeadlineId(), request.getPeriod(),request.getMaximumPeople());
+    }
+/*
+마감 기간 삭제
+ */
+    @DeleteMapping
+    public long deleteDeadline(@RequestParam(name = "id") long deadlineId){
+        return deadlineService.deleteDeadline(deadlineId);
+    }
+
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/controller/TeamController.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/controller/TeamController.java
@@ -1,0 +1,39 @@
+package com.jointpurchases.domain.deadline.controller;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import com.jointpurchases.domain.deadline.model.dto.AddTeamMemberDto;
+import com.jointpurchases.domain.deadline.model.dto.CreateTeamDto;
+import com.jointpurchases.domain.deadline.model.dto.ModifyDeadlineDto;
+import com.jointpurchases.domain.deadline.service.TeamService;
+import com.jointpurchases.global.tool.LoginUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/team")
+public class TeamController {
+    private final TeamService teamService;
+/*
+팀 생성
+ */
+    @PostMapping
+    public CreateTeamDto.Response createTeam(@RequestPart(name = "dto") CreateTeamDto.Request request, @LoginUser final User user){
+        return teamService.createTeam(request.getDeadlineId(), user);
+    }
+/*
+팀 멤버 추가
+ */
+    @PutMapping
+    public AddTeamMemberDto.Response addTeamMember(@RequestPart(name = "dto") AddTeamMemberDto.Request request, @LoginUser final User user){
+        return teamService.addTeamMember(request.getTeamId(), user);
+    }
+/*
+팀 멤버 제거 및 팀 멤버가 0일때 팀 삭제
+ */
+    @DeleteMapping
+    public String deleteTeamMember(@RequestParam(name = "id") long id, @LoginUser final User user){
+        return teamService.deleteTeamMember(id, user);
+    }
+
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/model/dto/AddTeamMemberDto.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/model/dto/AddTeamMemberDto.java
@@ -1,0 +1,40 @@
+package com.jointpurchases.domain.deadline.model.dto;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AddTeamMemberDto {
+
+    /*
+팀 멤버 추가
+ */
+    @Getter
+    public static class Request {
+        private long teamId;
+        private User user;
+    }
+    /*
+    팀 멤버 추가 반환값
+    */
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class Response {
+        private long teamId;
+        private long userId;
+        private String userEmail;
+
+
+        public static CreateTeamDto.Response response(CreateTeamDto.Response response){
+            return CreateTeamDto.Response.builder().
+                    teamId(response.getTeamId()).
+                    userId(response.getUserId()).
+                    userEmail(response.getUserEmail()).
+                    build();
+        }
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/model/dto/CeateDeadlineDto.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/model/dto/CeateDeadlineDto.java
@@ -1,0 +1,39 @@
+package com.jointpurchases.domain.deadline.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class CeateDeadlineDto {
+
+    @Getter
+    public static class Request{
+        private long productId;
+        private int period;
+        private int maximumPeople;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class Response {
+        private long productId;
+        private int maximumPeople;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+        private String status;
+
+        public static Response response(Response response) {
+            return Response.builder().
+                    maximumPeople(response.getMaximumPeople()).
+                    startDate(response.getStartDate()).
+                    endDate(response.getEndDate()).
+                    status(response.getStatus()).
+                    build();
+        }
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/model/dto/CreateTeamDto.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/model/dto/CreateTeamDto.java
@@ -1,0 +1,39 @@
+package com.jointpurchases.domain.deadline.model.dto;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CreateTeamDto {
+/*
+팀 추가
+ */
+    @Getter
+    public static class Request {
+        private long deadlineId;
+        private User user;
+    }
+/*
+팀 추가 반환값
+*/
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class Response {
+        private long teamId;
+        private long userId;
+        private String userEmail;
+
+
+        public static Response response(Response response){
+            return Response.builder().
+                    teamId(response.getTeamId()).
+                    userId(response.getUserId()).
+                    userEmail(response.getUserEmail()).
+                    build();
+        }
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/model/dto/ModifyDeadlineDto.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/model/dto/ModifyDeadlineDto.java
@@ -1,0 +1,39 @@
+package com.jointpurchases.domain.deadline.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ModifyDeadlineDto {
+    @Getter
+    public static class Request{
+        private long deadlineId;
+        private int period;
+        private int maximumPeople;
+    }
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class Response {
+        private long deadlineId;
+        private int maximumPeople;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+        private String status;
+
+        public static ModifyDeadlineDto.Response response(ModifyDeadlineDto.Response response) {
+            return ModifyDeadlineDto.Response.builder().
+                    deadlineId(response.getDeadlineId()).
+                    maximumPeople(response.getMaximumPeople()).
+                    startDate(response.getStartDate()).
+                    endDate(response.getEndDate()).
+                    status(response.getStatus()).
+                    build();
+        }
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/model/entity/DeadlineEntity.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/model/entity/DeadlineEntity.java
@@ -1,0 +1,41 @@
+package com.jointpurchases.domain.deadline.model.entity;
+
+import com.jointpurchases.domain.product.model.entity.Product;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "DEADLINE")
+public class DeadlineEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private int maximumPeople;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String status;
+
+    @OneToOne
+    @JoinColumn(name = "PRODUCT_ID")
+    private Product product;
+
+    @Builder
+    public DeadlineEntity(int maximumPeople, LocalDateTime startDate, LocalDateTime endDate, String status, Product product){
+        this.maximumPeople = maximumPeople;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+        this.product = product;
+    }
+
+    public void updateDeadline(LocalDateTime endDate, int maximumPeople){
+        this.endDate = endDate;
+        this.maximumPeople = maximumPeople;
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/model/entity/TeamEntity.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/model/entity/TeamEntity.java
@@ -1,0 +1,38 @@
+package com.jointpurchases.domain.deadline.model.entity;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "TEAM")
+public class TeamEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "DEADLINE_ID")
+    private DeadlineEntity deadline;
+
+    @OneToMany
+    @JoinColumn(name = "TEAM_ID")
+    private List<User> user = new ArrayList<>();
+
+    @Builder
+    public TeamEntity(DeadlineEntity deadline, User user){
+        this.deadline = deadline;
+        this.user.add(user);
+    }
+
+    public void addTeamMember(User user){
+        this.user.add(user);
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/repository/DeadlineRepository.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/repository/DeadlineRepository.java
@@ -1,0 +1,9 @@
+package com.jointpurchases.domain.deadline.repository;
+
+import com.jointpurchases.domain.deadline.model.entity.DeadlineEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DeadlineRepository extends JpaRepository<DeadlineEntity, Long> {
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/repository/TeamRepository.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/repository/TeamRepository.java
@@ -1,0 +1,13 @@
+package com.jointpurchases.domain.deadline.repository;
+
+import com.jointpurchases.domain.deadline.model.entity.TeamEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TeamRepository extends JpaRepository<TeamEntity, Long> {
+
+    Optional<TeamEntity> findByDeadlineId(long id);
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/service/DeadlineService.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/service/DeadlineService.java
@@ -1,0 +1,162 @@
+package com.jointpurchases.domain.deadline.service;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import com.jointpurchases.domain.deadline.model.dto.ModifyDeadlineDto;
+import com.jointpurchases.domain.deadline.model.entity.TeamEntity;
+import com.jointpurchases.domain.order.service.OrderService;
+import com.jointpurchases.domain.product.model.entity.Product;
+import com.jointpurchases.domain.product.repository.ProductRepository;
+import com.jointpurchases.domain.deadline.model.dto.CeateDeadlineDto;
+import com.jointpurchases.domain.deadline.model.entity.DeadlineEntity;
+import com.jointpurchases.domain.deadline.repository.TeamRepository;
+import com.jointpurchases.domain.deadline.repository.DeadlineRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeadlineService {
+    private final DeadlineRepository deadlineRepository;
+    private final TeamRepository teamRepository;
+    private final OrderService orderService;
+    private final ProductRepository productRepository;
+    @Autowired
+    private final JavaMailSender mailSender;
+    private static final HashMap<Long, Timer> sendEmailMap = new HashMap<>();
+
+/*
+마감 기한 설정
+*/
+    public CeateDeadlineDto.Response createDeadline(long productId, int period , int maximumPeople){
+        LocalDateTime now = LocalDateTime.now();
+        Product product = productRepository.findById(productId).orElseThrow(()->new RuntimeException("상품이 없습니다."));
+
+        DeadlineEntity deadline = DeadlineEntity.builder().
+                maximumPeople(maximumPeople).
+                startDate(now).
+                endDate(now.plusDays(period)).
+                status("on").
+                product(product).
+                build();
+
+        deadlineRepository.save(deadline);
+
+        return CeateDeadlineDto.Response.builder().
+                productId(productId).
+                maximumPeople(deadline.getMaximumPeople()).
+                startDate(deadline.getStartDate()).
+                endDate(deadline.getEndDate()).
+                status(deadline.getStatus()).
+                build();
+    }
+/*
+마감 기간 수정
+ */
+    public ModifyDeadlineDto.Response modifyDeadline(long deadlineId, int period , int maximumPeople){
+        DeadlineEntity nowDeadline = deadlineRepository.findById(deadlineId).orElseThrow(() -> new RuntimeException("마감기간이 없습니다."));
+        LocalDateTime newEndDate = nowDeadline.getStartDate().plusDays(period);
+
+        if(newEndDate.isBefore(LocalDateTime.now())){
+           throw new RuntimeException("날짜 설정이 잘못 되었습니다. 현재 보다 이전 날짜입니다.");
+        }
+
+        nowDeadline.updateDeadline(newEndDate, maximumPeople);
+
+        deadlineRepository.save(nowDeadline);
+
+        return ModifyDeadlineDto.Response.builder().
+                deadlineId(deadlineId).
+                maximumPeople(nowDeadline.getMaximumPeople()).
+                startDate(nowDeadline.getStartDate()).
+                endDate(nowDeadline.getEndDate()).
+                status(nowDeadline.getStatus()).
+                build();
+    }
+/*
+마감 기간 삭제
+ */
+    public long deleteDeadline(long deadlineID){
+        deadlineRepository.deleteById(deadlineID);
+        return deadlineID;
+    }
+/*
+주문
+ */
+    public void callOrder(DeadlineEntity deadline, TeamEntity team){
+        List<User> user = team.getUser();
+
+        for(User users : user){
+            orderService.createOrder(users,deadline.getProduct().getPrice(),users.getAddress());
+        }
+
+        log.info(user.size()+"의 "+deadline.getProduct().getProductName()+"이 주문되었습니다.");
+    }
+/*
+하루 마다 메일 보낼 팀 확인
+ */
+    @Scheduled(cron = "* * 0 * * *")
+    private void setMailing(){
+        List<DeadlineEntity> teamEntities = deadlineRepository.findAll();
+        for(DeadlineEntity teamEntity : teamEntities){
+            if(teamEntity.getEndDate().isAfter(LocalDateTime.now()) && teamEntity.getEndDate().isBefore(LocalDateTime.now().plusDays(1)))
+                sendEmailMap.put(teamEntity.getId() , setTeamTimer(teamEntity.getId(), teamEntity.getEndDate()));
+        }
+        log.info(sendEmailMap.size()+"개의 팀의 메일이 예약되었습니다.");
+    }
+/*
+기간 만료 전 모든 인원 예약시 메일 보내기 예약 취소
+ */
+    public void cancelMail(long teamId){
+        try{
+            sendEmailMap.get(teamId).cancel();
+        } catch (NullPointerException e){
+            log.info("작업이 없습니다. "+e.getMessage());
+        }
+    }
+
+/*
+메일 보내기 스케줄링 설정
+ */
+    private Timer setTeamTimer(long teamId, LocalDateTime endDate){
+        Timer timer = new Timer();
+        Date parseEndDate = Timestamp.valueOf(endDate);
+
+        TimerTask timerTask = new TimerTask() {
+            @Override
+            public void run() {
+                expiredEndDate(teamRepository.findByDeadlineId(teamId).orElseThrow(() -> new RuntimeException("팀이 존재하지 않습니다.")));
+            }
+        };
+
+        timer.schedule(timerTask, parseEndDate);
+
+        return timer;
+    }
+/*
+공동구매 마감기한 만료 시 메일 전송
+ */
+    private void expiredEndDate(TeamEntity email){
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+        List<User> emailList= email.getUser();
+        mailMessage.setSubject("구매 주문 동의 여부");
+        mailMessage.setFrom("www.jointPurchase.com");
+        mailMessage.setText("구매 하실 건가요? test");
+
+        for(User emailId : emailList){
+            mailMessage.setTo(emailId.getEmail());
+            mailSender.send(mailMessage);
+            log.info(emailId.getEmail()+"에게 메일보내기 완료!");
+        }
+    }
+
+}

--- a/src/main/java/com/jointpurchases/domain/deadline/service/TeamService.java
+++ b/src/main/java/com/jointpurchases/domain/deadline/service/TeamService.java
@@ -1,0 +1,87 @@
+package com.jointpurchases.domain.deadline.service;
+
+import com.jointpurchases.domain.auth.model.entity.User;
+import com.jointpurchases.domain.deadline.model.dto.AddTeamMemberDto;
+import com.jointpurchases.domain.deadline.model.dto.CreateTeamDto;
+import com.jointpurchases.domain.deadline.model.entity.DeadlineEntity;
+import com.jointpurchases.domain.deadline.model.entity.TeamEntity;
+import com.jointpurchases.domain.deadline.repository.TeamRepository;
+import com.jointpurchases.domain.deadline.repository.DeadlineRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TeamService {
+
+    private final DeadlineRepository deadlineRepository;
+    private final TeamRepository teamRepository;
+    private final DeadlineService deadlineService;
+/*
+공동 구매팀 생성
+ */
+    public CreateTeamDto.Response createTeam(long deadlineId, User user){
+        DeadlineEntity deadline = deadlineRepository.findById(deadlineId).orElseThrow(() -> new RuntimeException("마감기간이 존재하지 않습니다."));
+
+        TeamEntity team = TeamEntity.builder().
+                deadline(deadline).
+                user(user).
+                build();
+
+        teamRepository.save(team);
+
+        return CreateTeamDto.Response.builder().
+                teamId(team.getId()).
+                userId(user.getId()).
+                userEmail(user.getEmail()).
+                build();
+    }
+/*
+공동 구매팀 인원 추가
+ */
+    public AddTeamMemberDto.Response addTeamMember(long teamId, User user){
+        TeamEntity nowTeam = teamRepository.findById(teamId).orElseThrow(() -> new RuntimeException("팀이 존재하지 않습니다."));
+        nowTeam.addTeamMember(user);
+/*
+마감 인원과 주문 인원 체크 후 바로 주문
+ */
+        if(nowTeam.getDeadline().getMaximumPeople() == nowTeam.getUser().size()){
+            deadlineService.callOrder(nowTeam.getDeadline(), nowTeam);
+            deadlineService.cancelMail(nowTeam.getId());
+            deadlineService.deleteDeadline(nowTeam.getDeadline().getId());
+            log.info(nowTeam.getId()+"주문 완료");
+
+            return AddTeamMemberDto.Response.builder().
+                    teamId(nowTeam.getDeadline().getId()).
+                    build();
+        } else{
+            teamRepository.save(nowTeam);
+
+            return AddTeamMemberDto.Response.builder().
+                    teamId(teamId).
+                    userId(user.getId()).
+                    userEmail(user.getEmail()).
+                    build();
+        }
+    }
+/*
+팀 인원 삭제
+ */
+    public String deleteTeamMember(long teamId, User user){
+        TeamEntity nowTeam = teamRepository.findById(teamId).orElseThrow(() -> new RuntimeException("팀이 존재하지 않습니다."));
+
+        nowTeam.getUser().removeIf((item) -> item.getId().equals(user.getId()));
+
+        int countMember = teamRepository.save(nowTeam).getUser().size();
+
+        if(countMember == 0){
+            teamRepository.deleteById(nowTeam.getId());
+            return teamId+"팀 삭제";
+        }
+
+        return user.getEmail()+"삭제";
+    }
+}

--- a/src/main/java/com/jointpurchases/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jointpurchases/domain/review/controller/ReviewController.java
@@ -54,7 +54,7 @@ dto 구성 : 리뷰ID(id), 제목(title), 내용(contents), 별점(rating),사�
 /*
 유저 리뷰 전체 삭제
  */
-    @DeleteMapping("/User")
+    @DeleteMapping("/user")
     public long deleteAllReviewByUserId(@LoginUser final User user){
         return reviewService.deleteAllReviewByUserId(user);
     }

--- a/src/main/java/com/jointpurchases/domain/review/controller/ReviewReadController.java
+++ b/src/main/java/com/jointpurchases/domain/review/controller/ReviewReadController.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(value = "/api/review")
+@RequestMapping(value = "/api/review/read")
 public class ReviewReadController {
     private final ReviewReadService reviewReadService;
     /*

--- a/src/main/java/com/jointpurchases/domain/review/service/ReviewService.java
+++ b/src/main/java/com/jointpurchases/domain/review/service/ReviewService.java
@@ -91,7 +91,7 @@ public class ReviewService {
 리뷰 수정
  */
     public ModifyReviewDto.Response modifyReview(long id, String title, String contents, int rating, @Nullable List<MultipartFile> files, User user) throws IOException {
-        ReviewEntity nowReview = reviewRepository.findById(id).get();
+        ReviewEntity nowReview = reviewRepository.findById(id).orElseThrow(() -> new RuntimeException("리뷰가 없습니다."));
         List<ReviewImageEntity> nowReviewImageList = reviewImageRepository.findAllByReviewId(id);
         LocalDateTime now = LocalDateTime.now();
         String projectPath = System.getProperty("user.dir") + "\\image\\";//기본 폴더 경로

--- a/src/main/java/com/jointpurchases/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/jointpurchases/global/config/WebSecurityConfig.java
@@ -62,6 +62,8 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/category/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET,"/api/product/**").permitAll()
                         .requestMatchers("/v3/**", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/api/review/read/product").permitAll()
+                        .requestMatchers("/api/deadline/**").hasRole("ADMIN")
                         .requestMatchers("/").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );


### PR DESCRIPTION
# 작업 내용 요약
- 마감 기간 구현
- 공동 구매 팀 구현
- 마감 기간은 하루 단위로 설정이 가능합니다.
- 마감 인원 설정 가능합니다.
- 마감 기간 까지 마감 인원이 다 모이지 않을 때 각 인원에게 메일을 보냅니다.
- 메일 스케줄은 매일 00시에 그날 마감 기간이 포함되어 있는 팀이 스케줄링 됩니다.
- 팀 인원 삭제로 모든 팀원이 없을 때는 팀이 삭제됩니다.
- 리뷰 코드 수정(reviewReadContoller의 api/review -> api/review/read로 수정)
- 리뷰 코드 오타 수정
# 변경점
## AS-IS


## TO-BE
- 조회 구현
- 팀 원 전체 모였을 경우 구매(단일 구매 부분이 구현 된 후)

# 테스트
- 마감 기간 생성 ![마감 기간 생성](https://github.com/joint-purchase/joint-purchase/assets/141152983/d395c2e3-9fbb-4bae-b172-8144dd3a76b1)
- 마감 기간 수정 ![마감 기간 수정 postman](https://github.com/joint-purchase/joint-purchase/assets/141152983/0fa1f737-cea0-4f6c-aa02-bbabd3a3314e)
- 마감 기간 삭제 ![마간 기간 삭제](https://github.com/joint-purchase/joint-purchase/assets/141152983/6e8b3858-952b-4568-b5d0-36f1bffbae25)
![마감 기간 삭제전 mysql](https://github.com/joint-purchase/joint-purchase/assets/141152983/ba4ecd89-e493-4857-be75-e6ee6e91f47e)
![마감 기간 삭제 mysql](https://github.com/joint-purchase/joint-purchase/assets/141152983/c4537046-beb4-4fe2-9cbd-cd93324350cc)
- 팀생성 ![팀 생성](https://github.com/joint-purchase/joint-purchase/assets/141152983/34188b21-a527-4ee1-b4dc-db8381b7bb0a)
- 팀 멤버 추가 ![팀 멤버 추가post man](https://github.com/joint-purchase/joint-purchase/assets/141152983/77049b5e-6ba3-4c4a-9f83-c674fb3f5a72)
- 팀 멤버 삭제 ![팀멤버 삭제 postman](https://github.com/joint-purchase/joint-purchase/assets/141152983/db468d16-035c-4728-9d50-1a2b9d0e7c09)
- 팀 멤버 0으로 인한 팀 삭제 ![팀 멤버 전체 삭제 후 팀 삭제](https://github.com/joint-purchase/joint-purchase/assets/141152983/cc7a1ec1-f3a0-4387-bd6e-e64267bc585f)
![팀멤버 전체 삭제 후 팀삭제전](https://github.com/joint-purchase/joint-purchase/assets/141152983/cd5daa5d-ad19-4ca5-bb77-08736ab09e57)
![팀 멤버 전체 삭제 후 팀 삭제mysql](https://github.com/joint-purchase/joint-purchase/assets/141152983/874e4aa6-cfa6-4f91-9e05-53ab18628e30)









